### PR TITLE
Add YARD as a development dependency

### DIFF
--- a/padrino-assets.gemspec
+++ b/padrino-assets.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 2.0.0'
   s.add_development_dependency 'rspec-html-matchers'
+  s.add_development_dependency 'yard'
 end


### PR DESCRIPTION
The Rakefile requires yard, so no rake tasks will run if that gem isn't installed.  I added it as a dev dependency in the gemspec.
